### PR TITLE
Extended functionality/compatibility: 1D, non-default domains, clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,23 +30,25 @@ In the context of images, a Lookup Table (LUT) is a table describing a transform
 Warning: If your input image is in a Log colorspace, make sure to choose a Log LUT!
 ```
 $ cubelut --help
-usage: cubelut [-h] [-o OUT] [-g] [-v] [-t [THUMB]] [-j JOBS] LUT INPUT
-
-Tool for applying Adobe Cube LUTs to images
-
-positional arguments:
-  LUT                   Cube LUT filename/folder
-  INPUT                 input image filename/folder
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -o OUT, --out OUT     output image folder
-  -g, --log             convert to Log before LUT
-  -v, --verbose         control verbosity and info messages
-  -t [THUMB], --thumb [THUMB]
-                        resizes to <= 500px, optionally specify max size
-  -j JOBS, --jobs JOBS  number of processes to spawn, defaults to number of
-                        logical CPUs
+usage: pycubelut.py [-h] [-o OUT] [-g] [-c] [-v] [-t [THUMB]] [-j JOBS] LUT INPUT                                                      
+                                                                                   
+Tool for applying Adobe Cube LUTs to images                                        
+                                                                                   
+positional arguments:                                                              
+  LUT                   Cube LUT filename/folder                                   
+  INPUT                 input image filename/folder                                
+                                                                                   
+optional arguments:                                                                
+  -h, --help            show this help message and exit                            
+  -o OUT, --out OUT     output image folder                                        
+  -g, --log             convert to Log before LUT                                  
+  -c, --clip            whether to clip LUT values to the domain's bounds,         
+                        which can fix issues with certain LUT exports              
+  -v, --verbose         control verbosity and info messages                        
+  -t [THUMB], --thumb [THUMB]                                                      
+                        resizes to <= 500px, optionally specify max size           
+  -j JOBS, --jobs JOBS  number of processes to spawn, defaults to number of        
+                        logical CPUs                                               
 ```
 
 ### Multiple LUTs

--- a/pycubelut.py
+++ b/pycubelut.py
@@ -171,7 +171,10 @@ def main():
             elif not os.path.isfile(file_path):
                 continue
             else:
-                luts.append(read_lut(file_path, clip=args.clip))
+                try:
+                    luts.append(read_lut(file_path, clip=args.clip))
+                except Exception as e:
+                    logging.error(f"Could not read '{file_path}' ({e}); skipping this LUT.")
     else:
         # Exit if args.LUT is not a file
         if not os.path.isfile(args.LUT):

--- a/pycubelut.py
+++ b/pycubelut.py
@@ -40,7 +40,7 @@ def read_lut(lut_path, clip=False):
     return lut
 
 
-def process_image(image_path, output_path, thumb, lut, log, no_prefix=False):
+def process_image(image_path, output_path, thumb, lut, log, no_prefix=False, quality=95):
     """Opens the image at <image_path>, transforms it using the passed
     <lut> with trilinear interpolation, and saves the image at
     <output_path>, or if it is None, then the same folder as <image_path>.
@@ -97,7 +97,7 @@ def process_image(image_path, output_path, thumb, lut, log, no_prefix=False):
         output_filename = lut.name + image_ext
         if not no_prefix:
             output_filename = os.path.basename(image_filename) + '_' + output_filename
-        new_im.save(os.path.join(output_dir, output_filename), quality=95)
+        new_im.save(os.path.join(output_dir, output_filename), quality=quality)
 
 def main():
     # import tifffile as tiff
@@ -117,6 +117,8 @@ def main():
     parser.add_argument("-np", "--no-prefix",
                         help="whether to not prefix output files with the image filename "
                              "(only possible if INPUT is not a directory)", action="store_true")
+    parser.add_argument("-q", "--quality", type=int, default=95,
+                        help="the output image quality (max. 100, default 95)")
     parser.add_argument("-g", "--log",
                         help="convert to Log before LUT", action="store_true")
     parser.add_argument("-c", "--clip",
@@ -188,12 +190,12 @@ def main():
             if os.path.isfile(file_path):
                 for lut in luts:
                     image_queue.append((file_path, args.out,
-                        args.thumb, lut, args.log, args.no_prefix))
+                        args.thumb, lut, args.log, args.no_prefix, args.quality))
     else:
         # process single image
         for lut in luts:
             image_queue.append((args.INPUT, args.out,
-                args.thumb, lut, args.log, args.no_prefix))
+                args.thumb, lut, args.log, args.no_prefix, args.quality))
 
     logging.info("Starting pool with max " + str(len(image_queue))
                     + " tasks in queue")

--- a/pycubelut.py
+++ b/pycubelut.py
@@ -24,6 +24,7 @@ def read_lut(lut_path, clip=False):
         upper bounds
     """
     lut: Union[LUT3x1D, LUT3D] = read_LUT_IridasCube(lut_path)
+    lut.name = os.path.splitext(os.path.basename(lut_path))[0]  # use base filename instead of internal LUT name
 
     if clip:
         if lut.domain[0].max() == lut.domain[0].min() and lut.domain[1].max() == lut.domain[1].min():

--- a/pycubelut.py
+++ b/pycubelut.py
@@ -52,11 +52,18 @@ def process_image(image_path, output_path, thumb, lut, log):
             image_ext = "_thumb" + image_ext
         logging.debug("Applying LUT: " + lut.name)
         im_array = np.asarray(im, dtype=np.float32) / 255
+        is_non_default_domain = not np.array_equal(lut.domain, np.array([[0., 0., 0.], [1., 1., 1.]]))
+        dom_scale = None
+        if is_non_default_domain:
+            dom_scale = lut.domain[1] - lut.domain[0]
+            im_array = im_array * dom_scale + lut.domain[0]
         if log:
             im_array = im_array ** (1/2.2)
         im_array = lut.apply(im_array)
         if log:
             im_array = im_array ** (2.2)
+        if is_non_default_domain:
+            im_array = (im_array - lut.domain[0]) / dom_scale
         im_array = im_array * 255
         new_im = Image.fromarray(np.uint8(im_array))
         if output_path is None:

--- a/pycubelut.py
+++ b/pycubelut.py
@@ -5,147 +5,14 @@ park.yoonsik@icloud.com
 === Description ===
 A library and standalone tool to apply Adobe Cube LUTs to common image
 formats. This supports applying multiple LUTs and batch image processing.
-The CubeLUT class has complete Cube LUT parsing and transform capabilities.
 """
 
 import logging
 import numpy as np
-from colour.algebra.interpolation import table_interpolation_tetrahedral, \
-    table_interpolation_trilinear
-from scipy.interpolate import RegularGridInterpolator
+from colour.io.luts.iridas_cube import read_LUT_IridasCube
 import os
 from multiprocessing import Pool
 
-
-class CubeLUT:
-    """This class holds Cube LUT data and methods to apply the LUT to 2D RGB
-    numpy arrays. This class only supports 3D LUTs.
-    === Attributes ===
-    filename:
-        Filename of the Cube LUT
-    title:
-        A self-description of the Cube LUT extracted from the file
-    data:
-        numpy array containing the actual LUT, with dimensions:
-        (self.size, self.size, self.size, 3). Initial RGB values can be
-        transformed as follows: [Red, Green, Blue, :] -> Ordered RGB values
-    size:
-        The LUT is a cube with dimensions of equal size: <self.size>.
-    dim:
-        The number of dimensions of the LUT. This class only supports 3D LUTs.
-    domain_min:
-        A tuple containing the lowest RGB values supported by the LUT, 
-        respectively.
-    domain_max
-        A tuple containing the highest RGB values supported by the LUT, 
-        respectively.
-    """
-
-    def __init__(self, lut_path):
-        """Initialize a CubeLUT class.
-
-        <lut_path> must be a valid path to a .cube file
-        """
-        self.data = None
-        self.dim = 0
-        self.size = 0
-        self.title = ""
-        self.filename = ""
-        self.domain_min = (0., 0., 0.)
-        self.domain_max = (1., 1., 1.)
-        self._read_cube_lut(lut_path)
-
-    def _read_cube_lut(self, lut_path):
-        """Internal function to parse Cube LUT files and initialize class
-        variables.
-
-        <lut_path> must be a valid path to a .cube file
-        """
-        logging.debug("Importing lut: " + lut_path)
-        self.filename = lut_path
-        lut_data = []
-        with open(lut_path, 'r') as lut_file:
-            for line in lut_file.readlines():
-                if line[0] == '#' or line.strip() == '':
-                    # skip comment/empty line
-                    continue
-                if "TITLE" in line:
-                    self.title = ' '.join(line.split()[1:])
-                elif "DOMAIN_MIN" in line:
-                    self.domain_min = tuple(float(x) for x in line.split()[1:])
-                elif "DOMAIN_MAX" in line:
-                    self.domain_max = tuple(float(x) for x in line.split()[1:])
-                elif "LUT_1D_SIZE" in line:
-                    self.dim = 1
-                    self.size = int(line.split()[1])
-                    raise Exception('1D not supported: ' + self.filename)
-                    # assert self.size <= 65536 and self.size >= 2
-                elif "LUT_3D_SIZE" in line:
-                    self.dim = 3
-                    self.size = int(line.split()[1])
-                    # assert self.size <= 256 and self.size >= 2
-                else:
-                    lut_data.append([float(num) for num in line.split()])
-        # convert self.data to numpy format
-        self.data = np.array(lut_data)
-        x = self.size
-        self.data = self.data.reshape([x, x, x, 3], order='F')
-        if self.domain_min != (0., 0., 0.) or self.domain_max != (1., 1., 1.):
-            logging.warning("nonstandard domain for LUT, output may be wrong")
-
-    def transform_tetrahedral(self, image, in_place=False):
-        """Returns the transformed <image>, using the LUT from <self.data>.
-        This uses tetrahedral interpolation, which is more accurate and
-        slower than trilinear interpolation. If <in_place> is True, the 
-        <image> array will be directly modified.
-
-        <image> is the 2D RGB array (i.e. 3D array)
-        <in_place> specifies if <image> should be transformed directly
-        """
-        if not in_place:
-            image = np.copy(image)
-
-        for i, row in enumerate(image):
-            image[i] = table_interpolation_tetrahedral(row, self.data)
-        return image
-
-    def transform_trilinear(self, image, in_place=False):
-        """Returns the transformed <image>, using the LUT from <self.data>.
-        This uses trilinear interpolation, which is faster than tetrahedral
-        interpolation. If <in_place> is True, the <image> array will be
-        directly modified.
-
-        <image> is the 2D RGB array (i.e. 3D array)
-        <in_place> specifies if <image> should be transformed directly
-        """
-        if not in_place:
-            image = np.copy(image)
-
-        for i, row in enumerate(image):
-            image[i] = table_interpolation_trilinear(row, self.data)
-        return image
-
-    def _buggy_transform_trilinear(self, image, in_place=False):
-        """Trilinear interpolation using scipy interpolation methods. Slower
-        than the <transform_trilinear> method, and has bugs.
-
-        <image> is the 2D RGB array (i.e. 3D array)
-        <in_place> specifies if <image> should be transformed directly
-        """
-        if not in_place:
-            image = np.copy(image)
-
-        # save image shape for later
-        orig_image_shape = image.shape
-        # change 2D RGB -> 1D RGB
-        image = image.reshape([-1, 3])
-        # equally spaced grid from 0 to 1
-        x = np.linspace(0, 1, self.size)
-        # for RGB channels respectively
-        for i in [0, 1, 2]:
-            i_func = RegularGridInterpolator((x, x, x), self.data[:, :, :, i])
-            image[:, i] = i_func(image[:])
-        return image.reshape(orig_image_shape)
 
 def process_image(image_path, output_path, thumb, lut, log):
     """Opens the image at <image_path>, transforms it using the passed
@@ -183,22 +50,21 @@ def process_image(image_path, output_path, thumb, lut, log):
                         int(im.size[1] * thumb / max(im.size)))
             im = im.resize(new_dims, Image.BICUBIC)
             image_ext = "_thumb" + image_ext
-        logging.debug("Applying LUT: " + lut.filename)
+        logging.debug("Applying LUT: " + lut.name)
         im_array = np.asarray(im, dtype=np.float32) / 255
         if log:
             im_array = im_array ** (1/2.2)
-        lut.transform_trilinear(im_array, in_place=True)
+        im_array = lut.apply(im_array)
         if log:
             im_array = im_array ** (2.2)
         im_array = im_array * 255
         new_im = Image.fromarray(np.uint8(im_array))
-        lutname = os.path.split(lut.filename)[1][:-5].replace(' ', '_')
         if output_path is None:
-            new_im.save(image_name + '_' + lutname + image_ext,
+            new_im.save(image_name + '_' + lut.name + image_ext,
                         quality=95)
         else:
             new_im.save(output_path + os.path.basename(image_name) +
-                        '_' + lutname + image_ext, quality=95)
+                        '_' + lut.name + image_ext, quality=95)
 
 def main():
     # import tifffile as tiff
@@ -263,14 +129,14 @@ def main():
             elif not os.path.isfile(file_path):
                 continue
             else:
-                luts.append(CubeLUT(file_path))
+                luts.append(read_LUT_IridasCube(file_path))
     else:
         # Exit if args.LUT is not a file
         if not os.path.isfile(args.LUT):
             logging.error(args.LUT + " doesn't exist")
             exit(1)
         # Single lut at <luts[0]>
-        luts.append(CubeLUT(args.LUT))
+        luts.append(read_LUT_IridasCube(args.LUT))
 
     image_queue = []
     # determine if input is a folder
@@ -299,7 +165,10 @@ def main():
 
     logging.info("Completed in" + '% 6.2f' % (end_time - start_time) + "s")
 
-__all__ = ['CubeLUT']
+
+__all__ = ['process_image']
+
+
 # Command Line Interface
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Changes (see also individual commits):

1. Use LUT implementations from the colour library, replacing the class CubeLUT. This adds **support for 1-dimensional cube LUTs**, among other things. This change addresses issue #1.
2. Add **support for non-default domains** (i.e. domains that are not [0,1]).
3. Add **option to clip LUT values to the domain's bounds**, which solves issues with some commercial LUTs, which may have been exported in a strange way. For example, it makes LUTs from LUTs.Store applicable, which contain negative values that result in strange artifacts when applied using pycubelut/colours.
4. Allow output filename composition and output image quality to be configured.